### PR TITLE
Update CombatMaster.js

### DIFF
--- a/CombatMaster.js
+++ b/CombatMaster.js
@@ -2797,7 +2797,7 @@ var CombatMaster = CombatMaster || (function() {
         } else if (status.sheet == 'Shaped') {
             spellName    = msg.content.match(/title=([^\n{}]*[^"\n{}])/);  
             spellName    = RegExp.$1;         
-            description  = msg.content.match(/content=([^\n{}]*[^"\n{}])/)  
+            description  = msg.content.match(/{{content=([^\n{}]*[^"\n{}])/)  
             description  = RegExp.$1;       
             if (msg.content.includes("CONCENTRATION")) {
                 concentrate = true


### PR DESCRIPTION
Using only "/content" matches the regex for the "hide_content" syntax ({{hide_content=1}}), which is used when the "Hide Content" option for Shaped 5E is used . Adding double brackets {{ eliminates this ambiguity, so it only matches the spell's description field.