### PR TITLE
Add condition functions to exposed API

### DIFF
--- a/CombatMaster.js
+++ b/CombatMaster.js
@@ -4533,6 +4533,8 @@ var CombatMaster = CombatMaster || (function() {
         CheckInstall: checkInstall,
         RegisterEventHandlers: registerEventHandlers,
         ObserveTokenChange: observeTokenChange,
+        addConditionToToken,
+        removeConditionFromToken,
         getConditions,
         getConditionByKey,
         sendConditionToChat,

--- a/CombatMaster.js
+++ b/CombatMaster.js
@@ -4535,6 +4535,7 @@ var CombatMaster = CombatMaster || (function() {
         ObserveTokenChange: observeTokenChange,
         addConditionToToken,
         removeConditionFromToken,
+	addTargetsToCondition,
         getConditions,
         getConditionByKey,
         sendConditionToChat,


### PR DESCRIPTION
Hey, love the extension! I'm working on a little personal inventory tracker script, and I want to add/remove conditions programmatically. Since the API commands ONLY look at `msg.selected`, I can't use those. It seems like a simple fix to expose these methods to the external API, but let me know if there's something I haven't considered.