### PR TITLE
Fix export function when desc includes quotes

### DIFF
--- a/CombatMaster.js
+++ b/CombatMaster.js
@@ -3199,7 +3199,8 @@ var CombatMaster = CombatMaster || (function() {
                 '}' : '&'+'#125'+';',
                 '[' : '&'+'#91'+';',
                 ']' : '&'+'#93'+';',
-                '"' : '&'+'quot'+';'
+                '"' : '&'+'quot'+';',
+                "&" : '&'+'amp'+';'
             },
             re=new RegExp('('+_.map(_.keys(entities),esRE).join('|')+')','g');
         return function(s){


### PR DESCRIPTION
A condition description including a quote is not properly escaped, resulting in a file which cannot be later imported into CM.  Add & to the escaped entities seems to fix the issue.